### PR TITLE
Expand Solidity version and other improvements

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -1,0 +1,32 @@
+[profile.default]
+src = "src"
+out = "out"
+libs = ["lib"]
+# The verbosity level to use during tests.
+verbosity = 3
+
+[fmt]
+bracket_spacing = true
+int_types = "long"
+line_length = 120
+multiline_func_header = "params_first"
+number_underscore = "thousands"
+quote_style = "double"
+tab_width = 4
+wrap_comments = false
+
+[rpc_endpoints]
+mainnet = "https://ethereum-rpc.publicnode.com"
+sepolia = "https://ethereum-sepolia-rpc.publicnode.com"
+base = "https://mainnet.base.org"
+arbitrum = "https://arbitrum-one-rpc.publicnode.com"
+
+[etherscan]
+mainnet = { key = "${ETHERSCAN_API_KEY}" }
+
+[fuzz]
+# The amount of fuzz runs to perform for each fuzz test case. 
+# Higher values gives more confidence in results at the cost of testing speed.
+runs = 256
+
+# See more config options https://github.com/foundry-rs/foundry/tree/master/config

--- a/remappings.txt
+++ b/remappings.txt
@@ -1,0 +1,2 @@
+@openzeppelin/contracts/=lib/openzeppelin-contracts/contracts/
+forge-std/=lib/forge-std/src/

--- a/src/IL2Registry.sol
+++ b/src/IL2Registry.sol
@@ -6,7 +6,7 @@
 // ***********************************************
 
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.20;
+pragma solidity ^0.8.20;
 
 /// @author darianb.eth
 /// @custom:project Durin
@@ -15,8 +15,10 @@ pragma solidity 0.8.20;
 interface IL2Registry {
     // ERC721 methods
     function ownerOf(uint256 tokenId) external view returns (address);
+
     // L2Registry specific methods
     function register(string calldata label, address owner) external;
+
     // Enables setting address by registrar
     function setAddr(
         bytes32 labelhash,

--- a/src/L2Registrar.sol
+++ b/src/L2Registrar.sol
@@ -6,7 +6,7 @@
 // ***********************************************
 
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.20;
+pragma solidity ^0.8.20;
 
 /// @author darianb.eth
 /// @custom:project Durin

--- a/src/L2Registry.sol
+++ b/src/L2Registry.sol
@@ -6,7 +6,7 @@
 // ***********************************************
 
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.20;
+pragma solidity ^0.8.20;
 
 /// @author darianb.eth + Unruggable(clowes.eth)
 /// @custom:project Durin

--- a/src/L2RegistryFactory.sol
+++ b/src/L2RegistryFactory.sol
@@ -13,9 +13,9 @@ pragma solidity ^0.8.20;
 /// @notice Factory contract for deploying new L2Registry instances
 /// @dev Uses OpenZeppelin Clones for gas-efficient deployment of registry contracts
 
-import "./L2Registry.sol";
-import "@openzeppelin/contracts/proxy/Clones.sol";
-import "@openzeppelin/contracts/utils/Create2.sol";
+import {L2Registry} from "./L2Registry.sol";
+import {Clones} from "@openzeppelin/contracts/proxy/Clones.sol";
+import {Create2} from "@openzeppelin/contracts/utils/Create2.sol";
 
 /// @title L2Registry Factory
 /// @notice Facilitates the deployment of new L2Registry instances with proper role configuration

--- a/src/L2RegistryFactory.sol
+++ b/src/L2RegistryFactory.sol
@@ -5,7 +5,7 @@
 // ▐▌  ▐▌▐▌ ▐▌▐▌  ▐▌▐▙▄▄▖▗▄▄▞▘  █ ▝▚▄▞▘▐▌  ▐▌▐▙▄▄▖
 // ***********************************************
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.20;
+pragma solidity ^0.8.20;
 
 /// @author darianb.eth
 /// @custom:project Durin

--- a/src/utils/BytesUtilsSub.sol
+++ b/src/utils/BytesUtilsSub.sol
@@ -6,7 +6,7 @@
 // ***********************************************
 
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.20;
+pragma solidity ^0.8.20;
 
 /// @author Unruggable
 /// @custom:project Durin

--- a/src/utils/StringUtils.sol
+++ b/src/utils/StringUtils.sol
@@ -6,13 +6,11 @@
 // ***********************************************
 
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.20;
+pragma solidity >=0.8.4;
 
 /// @author Unruggable
 /// @custom:project Durin
 /// @custom:company NameStone
-
-pragma solidity >=0.8.4;
 
 library StringUtils {
     /**

--- a/test/L2RegistrarTest.t.sol
+++ b/test/L2RegistrarTest.t.sol
@@ -22,7 +22,9 @@ contract L2RegistrarTest is Test {
         factory = new L2RegistryFactory(salt);
 
         // Deploy a registry through the factory
-        registry = L2Registry(factory.deployRegistry("TestNames", "TEST", "https://test.uri/"));
+        registry = L2Registry(
+            factory.deployRegistry("TestNames", "TEST", "https://test.uri/")
+        );
 
         // Deploy and set up registrar
         registrar = new L2Registrar(IL2Registry(address(registry)));
@@ -32,7 +34,6 @@ contract L2RegistrarTest is Test {
 
     function test_Available() public {
         string memory label = "test";
-        bytes32 labelhash = keccak256(abi.encodePacked(label));
 
         // Should be available before registration
         assertTrue(registrar.available(label));
@@ -68,10 +69,14 @@ contract L2RegistrarTest is Test {
         vm.startPrank(admin);
 
         // Deploy second registry
-        L2Registry registry2 = L2Registry(factory.deployRegistry("TestNames2", "TEST2", "https://test2.uri/"));
+        L2Registry registry2 = L2Registry(
+            factory.deployRegistry("TestNames2", "TEST2", "https://test2.uri/")
+        );
 
         // Verify both registries work independently
-        L2Registrar registrar2 = new L2Registrar(IL2Registry(address(registry2)));
+        L2Registrar registrar2 = new L2Registrar(
+            IL2Registry(address(registry2))
+        );
         registry2.addRegistrar(address(registrar2));
 
         // Register name in first registry
@@ -95,14 +100,25 @@ contract L2RegistrarTest is Test {
 
     function test_RegistryInitialization() public {
         vm.prank(admin);
-        L2Registry newRegistry = L2Registry(factory.deployRegistry("TestNames3", "TEST3", "https://test3.uri/"));
+        L2Registry newRegistry = L2Registry(
+            factory.deployRegistry("TestNames3", "TEST3", "https://test3.uri/")
+        );
 
         // Verify initialization worked
-        assertTrue(newRegistry.hasRole(newRegistry.DEFAULT_ADMIN_ROLE(), admin));
+        assertTrue(
+            newRegistry.hasRole(newRegistry.DEFAULT_ADMIN_ROLE(), admin)
+        );
         assertTrue(newRegistry.hasRole(newRegistry.ADMIN_ROLE(), admin));
 
         // Verify factory doesn't retain any roles
-        assertFalse(newRegistry.hasRole(newRegistry.DEFAULT_ADMIN_ROLE(), address(factory)));
-        assertFalse(newRegistry.hasRole(newRegistry.ADMIN_ROLE(), address(factory)));
+        assertFalse(
+            newRegistry.hasRole(
+                newRegistry.DEFAULT_ADMIN_ROLE(),
+                address(factory)
+            )
+        );
+        assertFalse(
+            newRegistry.hasRole(newRegistry.ADMIN_ROLE(), address(factory))
+        );
     }
 }


### PR DESCRIPTION
### Changelog:
- Updated Solidity version from `0.8.20` to `^0.8.20` - this allows other projects using a different higher compiler version to install `durin` as a foundry lib and build on top of it;
- Added `foundry.toml` configuration file and `remappings.txt` to map libraries;
- Explicitly specified imported contract and libs in the `L2RegistryFactoy.sol` to adhere to the project's guidelines;
- Removed unused test local variable;
